### PR TITLE
Don't redefine true and false in C23

### DIFF
--- a/kernel/include/types.h
+++ b/kernel/include/types.h
@@ -38,7 +38,15 @@ typedef unsigned long          size_t;
 typedef unsigned long          offset_t;
 typedef unsigned long          ulong_t;
 
-typedef enum { false=0, true } bool_t;
+#ifdef __STDC__
+	#if __STDC_VERSION__ >= 202311L
+		typedef bool bool_t;
+	#else
+		typedef enum { false=0, true } bool_t;
+	#endif
+#else
+	typedef enum { false=0, true } bool_t;
+#endif
 
 /*
 ** Offset of a field from a structure


### PR DESCRIPTION
In C23 true and false have finally been added to the language so they are at that point keywords that cannot be used in as identifiers.

(Forcing the C standard version in the makefile lead to a flood of errors and warnings, so it was easier to just fix this problem on its own)